### PR TITLE
ci: add Copilot review workflow + CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,21 @@
+# CodeRabbit configuration
+# Docs: https://docs.coderabbit.ai/guides/configure-coderabbit
+language: "en-AU"
+reviews:
+  profile: "assertive"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+      - master
+  path_filters:
+    - "!**/*.lock"
+    - "!**/node_modules/**"
+    - "!**/dist/**"
+    - "!**/build/**"

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,31 @@
+name: Copilot Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  request-copilot-review:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: Request Copilot Review
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              await github.rest.pulls.requestReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                reviewers: ['copilot']
+              });
+              core.info('Copilot review requested');
+            } catch (err) {
+              core.warning('Copilot review request skipped: ' + err.message);
+            }


### PR DESCRIPTION
Adds two CI/review files to the repo:

- `.github/workflows/copilot-review.yml` — automatically requests a Copilot review on non-draft PRs
- `.coderabbit.yaml` — CodeRabbit config (assertive profile, en-AU, auto-review on main/master, standard path filters)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMyFJo5eXjJZpX8tDtdmA9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated code reviews are now triggered for pull requests that are ready for review, helping feedback arrive sooner.
  * Review settings now prefer clearer, more consistent English (Australian) output and higher-level summaries.

* **Chores**
  * Automated reviews now skip drafts, lock files, dependencies, and build outputs to reduce unnecessary noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->